### PR TITLE
Prompt for subject and message

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+EMAIL_USER=youraddress@gmail.com
+EMAIL_PASS=your_app_password

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# Send-batch-auto-emails
+# Bulk Email Sender
+
+This repository contains a simple Streamlit application that lets you send
+personalized bulk emails directly from a web browser. The app is intended for
+use inside GitHub Codespaces so no additional GUI tools are required.
+
+## Quick Start
+
+1. **Create a virtual environment and install dependencies**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Provide Gmail credentials**
+   You can either export environment variables or simply type them directly into
+   the web interface. To avoid retyping every time, set environment variables or
+   create a `.env` file with your Gmail address and an
+   [app password](https://support.google.com/accounts/answer/185833):
+   ```bash
+   export EMAIL_USER="youraddress@gmail.com"
+   export EMAIL_PASS="your_app_password"
+   ```
+   Copy `.env.example` to `.env` if you want to store them in a file.
+
+3. **Run the app**
+   ```bash
+   streamlit run app.py --server.port 8080 --server.address 0.0.0.0
+   ```
+   In Codespaces, open the forwarded port (usually 8080) to view the Streamlit interface in your browser.
+
+
+4. **Upload your data**
+   Prepare a CSV or Excel file with at least an `email` column. Drag and drop
+   it onto the uploader. Optional `subject` and `message` columns can override
+   the subject and body you provide in the app.
+
+## Using the Application
+
+1. Open the forwarded port in your Codespace and you will see a simple web page.
+2. Drag and drop your CSV or Excel sheet onto the uploader (or click **Browse files**).
+3. Enter the subject and body of the email you want to send. If your file
+   includes `subject` or `message` columns, those values override what you type.
+4. Review the preview table to ensure your data looks correct and press
+   **Send Emails**.
+
+
+## File Format Example
+
+| email | subject | message |
+|-------|---------|---------|
+| alice@example.com | Hello | Hi Alice,\nthis is a test. |
+| bob@example.com | Hi Bob | Dear Bob,\nwelcome! |
+
+## Environment Variables
+
+- `EMAIL_USER` – Gmail address used to send emails.
+- `EMAIL_PASS` – Gmail app password for authentication.
+
+You can copy `.env.example` to `.env` and fill in your values. These variables
+are loaded automatically with `python-dotenv`, but they are optional because the
+web interface also lets you enter them manually.
+
+## Deployment Options
+
+This app runs well in a Codespace. For public hosting you can deploy to services
+like Streamlit Community Cloud, PythonAnywhere, or Render. Each platform may have
+specific environment variable configuration steps.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,81 @@
+import os
+import pandas as pd
+import streamlit as st
+import smtplib
+from email.message import EmailMessage
+from dotenv import load_dotenv
+
+st.set_page_config(page_title="Bulk Email Sender")
+
+# Load variables from a .env file if present
+load_dotenv()
+
+st.title("Bulk Email Sender")
+
+st.write(
+    """
+Upload a CSV or Excel file with at least an `email` column. You can also
+include optional `subject` and `message` columns for per-recipient
+customization. If those columns are missing, you'll be prompted for a single
+subject and message to use for everyone.
+    """
+)
+
+# Input fields for Gmail credentials. If environment variables exist, they
+# populate the defaults so users can leave them blank.
+email_user = st.text_input("Gmail address", value=os.getenv("EMAIL_USER", ""))
+email_pass = st.text_input(
+    "Gmail app password", value=os.getenv("EMAIL_PASS", ""), type="password"
+)
+
+
+# Drag-and-drop file uploader for CSV/Excel files
+uploaded_file = st.file_uploader(
+    "Drag and drop or choose a CSV or Excel file",
+    type=["csv", "xlsx"],
+)
+
+if uploaded_file is not None:
+    # Read the uploaded file into a DataFrame
+    if uploaded_file.name.endswith(".csv"):
+        df = pd.read_csv(uploaded_file)
+    else:
+        df = pd.read_excel(uploaded_file)
+
+    if "email" not in df.columns:
+        st.error("The uploaded file must contain an `email` column")
+        st.stop()
+
+    st.write("Preview of uploaded data:")
+    st.dataframe(df.head())
+
+    # Default subject and message if not provided in the file
+    default_subject = st.text_input("Email subject", "Hello from Streamlit")
+    default_message = st.text_area("Email message", "")
+
+    if st.button("Send Emails"):
+        if not email_user or not email_pass:
+            st.error("Please enter your Gmail address and app password")
+        else:
+            successes = 0
+            failures = 0
+            with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
+                try:
+                    server.login(email_user, email_pass)
+                except Exception as e:
+                    st.error(f"Failed to login: {e}")
+                    st.stop()
+                for _, row in df.iterrows():
+                    msg = EmailMessage()
+                    msg["From"] = email_user
+                    msg["To"] = row.get("email")
+                    msg["Subject"] = row.get("subject", default_subject)
+                    body = row.get("message", default_message)
+                    msg.set_content(body)
+                    try:
+                        server.send_message(msg)
+                        successes += 1
+                    except Exception as e:
+                        failures += 1
+                        st.write(f"Failed to send to {row.get('email')}: {e}")
+            st.success(f"Sent {successes} emails with {failures} failures")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-
+streamlit>=1.34.0
+pandas
+openpyxl
+python-dotenv


### PR DESCRIPTION
## Summary
- prompt for Gmail credentials directly in Streamlit app
- prompt for global subject and message
- document subject/message fields in README

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py --server.port 8501 --server.address 0.0.0.0`

------
https://chatgpt.com/codex/tasks/task_e_6846606418148329bcd17920c565daac