### PR TITLE
Improve README instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+EMAIL_USER=youraddress@gmail.com
+EMAIL_PASS=your_app_password

--- a/README.md
+++ b/README.md
@@ -1,1 +1,95 @@
-# Send-batch-auto-emails
+# Bulk Email Sender
+
+A simple Streamlit application for sending personalized bulk emails directly from a browser. It is designed to run entirely inside **GitHub Codespaces** so no desktop GUI is required.
+
+## Step 1: Verify Repository Setup
+
+Your repository should contain these files:
+
+- `app.py` – the Streamlit application.
+- `requirements.txt` – Python dependencies.
+- `.env.example` – sample environment variable file for Gmail credentials.
+
+Clone the repository or create a Codespace with these files in the project root.
+
+## Step 2: Choose a Web Interface
+
+This project uses **Streamlit** because it provides an easy way to build web apps with drag-and-drop file upload widgets and requires only a single command to start. It runs in the browser and works well inside Codespaces without extra configuration.
+
+## Step 3: Set Up the Python Environment
+
+Create a virtual environment and install the dependencies listed in `requirements.txt`:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+The `requirements.txt` file contains:
+
+```text
+streamlit>=1.34.0
+pandas
+openpyxl
+python-dotenv
+```
+
+## Step 4: Run the Application
+
+Provide your Gmail credentials either through environment variables or by editing a `.env` file based on `.env.example`:
+
+```bash
+export EMAIL_USER="youraddress@gmail.com"
+export EMAIL_PASS="your_app_password"
+```
+
+Then start the Streamlit server (replace the port if 8080 is already in use):
+
+```bash
+streamlit run app.py --server.port 8080 --server.address 0.0.0.0
+```
+
+Open the **Ports** tab in Codespaces, expose port `8080`, and click **Open in
+Browser** to view the interface.
+
+## Step 5: Upload Data and Send Emails
+
+1. Drag and drop a CSV or Excel file containing an `email` column. Optional `subject` and `message` columns can override the defaults.
+2. If prompted, enter your Gmail address and app password.
+3. Provide a subject and message if your file does not include them.
+4. Click **Send Emails** to send messages via Gmail SMTP. A summary of successes and failures appears when done.
+
+## Step 6: Example Data Format
+
+Your upload should have at minimum an `email` column:
+
+```csv
+email,subject,message
+person1@example.com,Hello,A personalized message here
+person2@example.com,,Another message
+```
+
+The `subject` and `message` columns are optional. If omitted, the values you
+enter in the app will be used for all recipients.
+
+## Step 7: Deployment Options
+
+The app works out of the box in Codespaces. To share it publicly you can deploy to services such as:
+
+- **Streamlit Community Cloud** – free for small projects.
+- **PythonAnywhere** – easy Python hosting with a free tier.
+- **Render** – supports deploying Streamlit apps with environment variables.
+
+Each platform requires setting `EMAIL_USER` and `EMAIL_PASS` as environment variables.
+
+## Testing
+
+Verify the code by compiling and launching the server:
+
+```bash
+python -m py_compile app.py
+streamlit run app.py --server.port 8080 --server.address 0.0.0.0
+```
+
+Stop the server with `Ctrl+C` once you see the URL.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,82 @@
+import os
+import pandas as pd
+import streamlit as st
+import smtplib
+from email.message import EmailMessage
+from dotenv import load_dotenv
+
+# Configure the page
+st.set_page_config(page_title="Bulk Email Sender")
+
+# Automatically load EMAIL_USER and EMAIL_PASS from a .env file if present
+load_dotenv()
+
+st.title("Bulk Email Sender")
+
+st.write(
+    """
+    Upload a CSV or Excel file with at least an `email` column. Optional
+    `subject` and `message` columns let you personalize each email.
+    If those columns are missing, you'll be asked for a subject and message
+    to use for all recipients.
+    """
+)
+
+# Input fields for Gmail credentials. If environment variables exist, they are
+# pre-filled so the user does not need to type them each time.
+email_user = st.text_input("Gmail address", value=os.getenv("EMAIL_USER", ""))
+email_pass = st.text_input(
+    "Gmail app password", value=os.getenv("EMAIL_PASS", ""), type="password"
+)
+
+# Drag-and-drop file uploader for recipient data
+uploaded_file = st.file_uploader(
+    "Drag and drop or choose a CSV or Excel file",
+    type=["csv", "xlsx"],
+)
+
+if uploaded_file is not None:
+    # Read the uploaded file into a pandas DataFrame
+    if uploaded_file.name.endswith(".csv"):
+        df = pd.read_csv(uploaded_file)
+    else:
+        df = pd.read_excel(uploaded_file)
+
+    if "email" not in df.columns:
+        st.error("The uploaded file must contain an `email` column")
+        st.stop()
+
+    st.write("Preview of uploaded data:")
+    st.dataframe(df.head())
+
+    # Default subject and message when the file lacks these columns
+    default_subject = st.text_input("Email subject", "Hello from Streamlit")
+    default_message = st.text_area("Email message", "")
+
+    if st.button("Send Emails"):
+        if not email_user or not email_pass:
+            st.error("Please enter your Gmail address and app password")
+        else:
+            successes = 0
+            failures = 0
+            # Connect to Gmail's SMTP server using SSL
+            with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
+                try:
+                    server.login(email_user, email_pass)
+                except Exception as e:
+                    st.error(f"Failed to login: {e}")
+                    st.stop()
+                for _, row in df.iterrows():
+                    msg = EmailMessage()
+                    msg["From"] = email_user
+                    msg["To"] = row.get("email")
+                    msg["Subject"] = row.get("subject", default_subject)
+                    body = row.get("message", default_message)
+                    msg.set_content(body)
+                    try:
+                        server.send_message(msg)
+                        successes += 1
+                    except Exception as e:
+                        failures += 1
+                        st.write(f"Failed to send to {row.get('email')}: {e}")
+            st.success(f"Sent {successes} emails with {failures} failures")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-
+streamlit>=1.34.0
+pandas
+openpyxl
+python-dotenv


### PR DESCRIPTION
## Summary
- clarify port forwarding instructions when running in Codespaces
- document example email file format

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py --server.port 8080 --server.address 0.0.0.0` (started then stopped)


------
https://chatgpt.com/codex/tasks/task_e_6846606418148329bcd17920c565daac